### PR TITLE
Added manager to module when casting so importable via migrations, re…

### DIFF
--- a/tests/test_model_meta.py
+++ b/tests/test_model_meta.py
@@ -218,9 +218,9 @@ class TestRegisteredModelMigration(MigrationTestCase):
     Check registered models can be migratated
     """
     def test_manager_deconstruct__deconstructs(self):
-        # This should serialise to the original manager
+        # This should serialise to the privacy manager
         string, imports = self.serialize(ModelWithPrivacyMeta.objects)
-        self.assertEqual(string, 'django.db.models.manager.Manager()')
+        self.assertEqual(string, 'gdpr_assist.models.CastPrivacyManager()')
 
         # And check it serialises back
         obj = self.serialize_round_trip(ModelWithPrivacyMeta.objects)


### PR DESCRIPTION
Added manager to module when casting so importable via migrations, removes need for deconstruct.

- Addresses issue #6 
- When managers (like UserManager) set use_in_migrations, deconstruct returned original manager, leading to incorrect then repeated migration. 
- Made Privacy{}Manager part or module so deconstruct is not needed and can be called as a normal manager in migrations. 