### PR TITLE
anonymise_db: add support for custom bulk anonymisation strategies

### DIFF
--- a/gdpr_assist/management/commands/anonymise_db.py
+++ b/gdpr_assist/management/commands/anonymise_db.py
@@ -1,10 +1,66 @@
 """
 Anonymise all personal data in the database
 """
-from django.core.management import BaseCommand
+from django.apps import apps
+from django.core.management import BaseCommand, CommandError
 
 from ... import app_settings
+from ...models import PrivacyModel
 from ...registry import registry
+
+
+class StrategyHelper:
+    CATEGORY_ANONYMISABLE = "anonymisable"
+    CATEGORY_UNANONYMISABLE = "unanonymisable"
+    CATEGORY_UNTAGGED = "untagged"
+
+    STRATEGY_ANONYMISE = "anonymise"
+    STRATEGY_DELETE = "delete"
+    STRATEGY_RETAIN = "retain"
+
+    AVAILABLE_STRATEGIES = {
+        STRATEGY_ANONYMISE,
+        STRATEGY_DELETE,
+        STRATEGY_RETAIN,
+    }
+
+    DEFAULT_STRATEGIES = {
+        CATEGORY_ANONYMISABLE: "anonymise",
+        CATEGORY_UNANONYMISABLE: "retain",
+        CATEGORY_UNTAGGED: "retain",
+    }
+
+    @staticmethod
+    def parse(text):
+        strategies = {}
+        for token in text.split(","):
+            if not token:
+                continue
+            try:
+                category, strategy = token.strip().split(":")
+            except ValueError:
+                raise CommandError(f"Could not parse strategy assignment: {token}")
+            if category not in StrategyHelper.DEFAULT_STRATEGIES:
+                raise CommandError(f"Unknown data category: {category}")
+            if strategy not in StrategyHelper.AVAILABLE_STRATEGIES:
+                raise CommandError(f"Unknown anonymisation strategy: {strategy}")
+            strategies[category] = strategy
+
+        # Assign a default strategy for any remaining categories
+        for category in StrategyHelper.DEFAULT_STRATEGIES:
+            if category not in strategies:
+                strategies[category] = StrategyHelper.DEFAULT_STRATEGIES[category]
+
+        return strategies
+
+    @staticmethod
+    def category_for_model(model):
+        if not issubclass(model, PrivacyModel):
+            return StrategyHelper.CATEGORY_UNTAGGED
+        privacy_meta = model.get_privacy_meta()
+        if privacy_meta.can_anonymise:
+            return StrategyHelper.CATEGORY_ANONYMISABLE
+        return StrategyHelper.CATEGORY_UNANONYMISABLE
 
 
 class Command(BaseCommand):
@@ -19,13 +75,29 @@ class Command(BaseCommand):
             default=True,
             help="Tells Django to NOT prompt the user for input of any kind.",
         )
+        parser.add_argument(
+            "--data-strategies",
+            "--strategies",
+            "-s",
+            dest="strategies",
+            default="anonymisable:anonymise, unanonymisable:retain, untagged:retain",
+            help="Configures the anonymisation strategies that will be applied.",
+        )
 
     def handle(self, *args, **options):
         if not app_settings.GDPR_CAN_ANONYMISE_DATABASE:
             raise ValueError("Database anonymisation is not enabled")
+
         interactive = options["interactive"]
+        strategies = StrategyHelper.parse(options["strategies"])
 
         if interactive:  # pragma: no cover
+            self.stdout.write(
+                "The following data anonymisation strategies will be applied:"
+            )
+            for category, strategy in strategies.items():
+                self.stdout.write(" - {category} data: {strategy.upper()}")
+
             confirm = input(
                 """Warning!
 You have requested that all personal information in the database is anonymised.
@@ -39,8 +111,40 @@ Are you sure you want to do this?
             confirm = "yes"
 
         if confirm == "yes":
-            for model in registry.models_allowed_to_anonymise():
-                model.objects.all().anonymise()
+            # Validate that we can determine a specific anonymisation strategy
+            # for every model in the application before modifying any data
+            for model in apps.get_models():
+                category = StrategyHelper.category_for_model(model)
+                strategy = strategies.get(category)
+                if strategy is None:
+                    raise CommandError(
+                        """Missing anonymisation strategy for model {model}!""",
+                        """Please check your anonymisation settings."""
+                    )
+
+            # Begin applying the requested anonymisation strategy to each model
+            for model in apps.get_models():
+                category = StrategyHelper.category_for_model(model)
+                strategy = strategies.get(category)
+
+                if strategy == StrategyHelper.STRATEGY_ANONYMISE:
+                    if issubclass(model, PrivacyModel) and model.check_can_anonymise():
+                        model.objects.all().anonymise()
+                    else:
+                        raise CommandError(
+                            """Cannot anonymise {category} model {model}!""",
+                            """Please check your anonymisation settings."""
+                        )
+
+                elif strategy == StrategyHelper.STRATEGY_DELETE:
+                    model.objects.all.delete()
+
+                elif strategy == StrategyHelper.STRATEGY_RETAIN:
+                    if issubclass(model, PrivacyModel) and model.check_can_anonymise():
+                        raise CommandError(
+                            """Refusing to retain anonymisable model {model}!""",
+                            """Please check your anonymisation settings."""
+                        )
 
             msg = "{} models anonymised.".format(
                 len(registry.models_allowed_to_anonymise())

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,12 +4,18 @@ Test management commands
 import sys
 from io import StringIO
 
-from django.core.management import call_command
+from django.core.management import (
+    CommandError,
+    call_command,
+)
 from django.test import TestCase
+
+from gdpr_assist.management.commands.anonymise_db import StrategyHelper
 
 from .tests_app.models import (
     ModelWithPrivacyMeta,
     ModelWithPrivacyMetaCanNotAnonymise,
+    ModelWithoutPrivacyMeta,
 )
 
 
@@ -31,6 +37,67 @@ class Capturing(list):
         self.extend(str(line) for line in self._stringio.getvalue().splitlines())
         sys.stdout = self._stdout
         sys.stderr = self._stderr
+
+
+class TestStrategyHelper(TestCase):
+
+    def test_strategy_parser_defaults(self):
+        text = ""
+        expected = {
+            "anonymisable": "anonymise",
+            "unanonymisable": "retain",
+            "untagged": "retain",
+        }
+
+        strategies = StrategyHelper.parse(text)
+
+        self.assertEqual(expected, strategies)
+
+    def test_strategy_parser_custom(self):
+        text = "unanonymisable:delete,untagged:delete"
+        expected = {
+            "anonymisable": "anonymise",
+            "unanonymisable": "delete",
+            "untagged": "delete",
+        }
+
+        strategies = StrategyHelper.parse(text)
+
+        self.assertEqual(expected, strategies)
+
+    def test_strategy_parser_padding(self):
+        text = " anonymisable:anonymise ,	unanonymisable:delete ,untagged:retain "
+        expected = {
+            "anonymisable": "anonymise",
+            "unanonymisable": "delete",
+            "untagged": "retain",
+        }
+
+        strategies = StrategyHelper.parse(text)
+
+        self.assertEqual(expected, strategies)
+
+    def test_strategy_parser_invalid_assignments(self):
+        text = "untagged:remove"
+
+        with self.assertRaises(CommandError):
+            StrategyHelper.parse(text)
+
+    def test_category_for_model(self):
+        models = [
+            ModelWithPrivacyMeta,
+            ModelWithPrivacyMetaCanNotAnonymise,
+            ModelWithoutPrivacyMeta,
+        ]
+        expected = [
+            "anonymisable",
+            "unanonymisable",
+            "untagged",
+        ]
+
+        categories = [StrategyHelper.category_for_model(model) for model in models]
+
+        self.assertEqual(expected, categories)
 
 
 class CommandTestCase(TestCase):
@@ -87,6 +154,36 @@ class TestAnonymiseCommand(CommandTestCase):
 
         obj_1.refresh_from_db()
         self.assertFalse(obj_1.is_anonymised())
+
+    def test_refuse_anonymise_unanonymisable(self):
+        obj_1 = ModelWithPrivacyMetaCanNotAnonymise.objects.create(
+            chars="test", email="test@example.com"
+        )
+        strategies = "unanonymisable:anonymise"
+
+        self.assertFalse(obj_1.check_can_anonymise())
+        with self.assertRaises(CommandError):
+            self.run_command("anonymise_db", interactive=False, strategies=strategies)
+
+    def test_refuse_anonymise_untagged(self):
+        obj_1 = ModelWithoutPrivacyMeta.objects.create(
+            chars="test", email="test@example.com"
+        )
+        strategies = "untagged:anonymise"
+
+        self.assertFalse(hasattr(obj_1, "check_can_anonymise"))
+        with self.assertRaises(CommandError):
+            self.run_command("anonymise_db", interactive=False, strategies=strategies)
+
+    def test_refuse_retain_anonymisable(self):
+        obj_1 = ModelWithPrivacyMeta.objects.create(
+            chars="test", email="test@example.com"
+        )
+        strategies = "anonymisable:retain"
+
+        self.assertTrue(obj_1.check_can_anonymise())
+        with self.assertRaises(CommandError):
+            self.run_command("anonymise_db", interactive=False, strategies=strategies)
 
 
 class TestRerunCommand(CommandTestCase):


### PR DESCRIPTION
This pull request adds support for configurable bulk data anonymisation strategies to the `anonymise_db` management command.

Django models are allocated to one of three _categories_ based on the privacy metadata that they have configured.  Either they are `anonymisable` (they have anonymisation configured and enabled), `unanonymisable` (they are configured to disallow anonymisation), or they are `untagged` (no configuration is provided for the model).

There are three possible _strategies_ in the initial implementation: `anonymise` (the contents of the model records will be anonymised), `delete` (the records for the model will be deleted) and `retain` (the model's records will be left as-is).

To configure the anonymisation strategy at runtime, the `anonymisation_db` command is supplied with a `--data-strategies` (or equivalently, `--strategies` or `-s`) flag that contains a list of comma-separated `<category>:<strategy>` mappings.

The default configuration is that anonymisable records are anonymised, unanonymisable records are retained, and untagged records are retained.

Resolves #39.