### PR TITLE
Performance: flip conditional order during model anonymisation in force-mode

### DIFF
--- a/gdpr_assist/models.py
+++ b/gdpr_assist/models.py
@@ -224,7 +224,7 @@ class PrivacyModel(models.Model):
             return
 
         # Only anonymise things once to avoid a circular anonymisation
-        if self.is_anonymised() and not force:
+        if not force and self.is_anonymised():
             return
 
         pre_anonymise.send(sender=self.__class__, instance=self)


### PR DESCRIPTION
This avoids evaluation and invocation of the `is_anonymised` method on the model to be anonymised.  The method involves a database query to perform an existence check.

Relates to #44 (performance optimizations).