### PR TITLE
Pass for_bulk=True to 'anonymise' method call from anonymise_db management command

### DIFF
--- a/gdpr_assist/management/commands/anonymise_db.py
+++ b/gdpr_assist/management/commands/anonymise_db.py
@@ -40,7 +40,7 @@ Are you sure you want to do this?
 
         if confirm == "yes":
             for model in registry.models_allowed_to_anonymise():
-                model.objects.all().anonymise()
+                model.objects.all().anonymise(for_bulk=True)
 
             msg = "{} models anonymised.".format(
                 len(registry.models_allowed_to_anonymise())


### PR DESCRIPTION
The `for_bulk` parameter, which can be passed to an individual model's `anonymise` method, or to the same method on the `PrivacyQuerySet`, determines whether a `PrivacyAnonymised` model will be saved for each anonymised object.

If it's not necessary to store those models (as it may not be during typical full-database anonymisation (todo: is that a reasonable assumption?)), then we can skip this step.

Relates to #44 (performance optimizations).