### PR TITLE
Add freezegun to setup.py dev-extras dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,7 @@ setup(
             "tox",
             "pillow",
             "model_bakery",
+            "freezegun",
             # Docs
             "sphinx",
             "sphinx-autobuild",


### PR DESCRIPTION
This makes it easier to run tests locally; by using `pip install -e .[dev]` from the project directory, development dependencies are installed, allowing unit tests to run using `python setup.py test`.