### PR TITLE
docs: fix `anonymise_<field_name>` example in usage docs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -22,7 +22,7 @@ Define privacy settings in a ``PrivacyMeta`` class on your model::
             fields = ['display_name', 'private_data']
 
             def anonymise_private_data(self, instance):
-                return 0
+                instance.private_data = 0
 
             def search(self, value):
                 return self.model.objects.filter(display_name__icontains=value)


### PR DESCRIPTION
I noticed the example in the usage docs doesn't match the [privacy meta docs](https://django-gdpr-assist.readthedocs.io/en/latest/privacy_meta.html#anonymise-field-name-self-instance) says:

![2024-08-13_07-20](https://github.com/user-attachments/assets/742f51c6-93ed-4908-94f6-40beee43274d)


https://github.com/wildfish/django-gdpr-assist/blob/250c63fca446cc6406535b57adfa3b0b5d6467c4/docs/privacy_meta.rst#L100-L110